### PR TITLE
fix: remove ellipses from chatInput placeholder

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -82,7 +82,7 @@
                         <input 
                             type="text" 
                             id="chatInput" 
-                            placeholder="Ask about courses, lessons, or specific content..."
+                            placeholder="Ask about courses, lessons, or specific content."
                             autocomplete="off"
                         >
                         <button id="sendButton">


### PR DESCRIPTION
Replace ellipses (...) with period (.) in chatInput placeholder text as requested in issue #2.